### PR TITLE
Add avatar size limit

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -456,4 +456,9 @@ div[draggable='true'] {
 .selected-project-description {
     white-space: pre-line; /* honor line breaks that the user typed */
 }
+
+/* github avatar resizes -- github stopped respecting the &s parameter
+ * for default generated avatar images, so we manually do it here */
+img[src$="s=40"] { width: 40px; height: 40px; }
+img[src$="s=120"] { width: 120px; height: 120px; }
 </style>


### PR DESCRIPTION
for default generated avatars, github does not respect the 's' query parameter to control the size.

As of 2017-09 the following image respects the s parameter and is  40x40 pixels:
https://avatars0.githubusercontent.com/u/97195?v=4&s=40

but this image does not respect the s parameter:
https://avatars3.githubusercontent.com/u/28970878?v=4&s=40

Fixes https://github.com/bkkhack/hackmap/issues/16