### PR TITLE
When the user is logged in, apply their authentication to all API calls

### DIFF
--- a/src/github-issues.js
+++ b/src/github-issues.js
@@ -27,9 +27,10 @@ export default class GitHubIssueService {
     // authenticated client for all operations. Authenticated calls have a
     // higher rate limit, even for calls that don't require authentication
     if (auth.isLoggedIn()) {
-      this.ensureAuthenticatedClient()
+      this.ensureAuthenticatedClient().then(() => this.startPolling())
+    } else {
+      this.startPolling()
     }
-    this.startPolling()
   }
 
   startPolling () {


### PR DESCRIPTION
Authenticated API calls have a higher rate limit, so if the user is already logged in, we should use that authentication information to get the higher rate limit.

In the code, by chaining the `startPolling()` function as a promise, we ensure that the authenticated HTTP client will be used for all operations.