### PR TITLE
read floorplan image from issue metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,7 @@ Now, after starting the webpack development webserver, navigating to https://bkk
     - The client id should be set in `src/github-oauth.js`
     - The secret token should be configured in the `bkkhackmap` heroku instance.
 2. Create a new GitHub issue tagged with "BKKHack Main Thread". This issue will be used as the back-end data store.
-3. Create a black and transparent SVG that represents the floor plan of the hack night venue. Save it as `images/floorplan.svg`.
-
+3. Create a black and transparent SVG that represents the floor plan of the hack night venue. Uploaded it to the GitHub issue (i.e. paste it into the text field) and refer to it in an html comment of the form `<!-- floorplan: http://example.com/floorplan.svg -->`.
 
 [build badge]: https://travis-ci.org/bkkhack/hackmap.svg?branch=master
 [build link]: https://travis-ci.org/bkkhack/hackmap

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Now, after starting the webpack development webserver, navigating to https://bkk
     - The client id should be set in `src/github-oauth.js`
     - The secret token should be configured in the `bkkhackmap` heroku instance.
 2. Create a new GitHub issue tagged with "BKKHack Main Thread". This issue will be used as the back-end data store.
-3. Create a black and transparent SVG that represents the floor plan of the hack night venue. Uploaded it to the GitHub issue (i.e. paste it into the text field) and refer to it in an html comment of the form `<!-- floorplan: http://example.com/floorplan.svg -->`.
+3. Create a black and transparent SVG that represents the floor plan of the hack night venue. Upload it to the GitHub issue (i.e. paste it into the textarea) and refer to it in an html comment of the form `<!-- floorplan: http://example.com/floorplan.svg -->`.
 
 [build badge]: https://travis-ci.org/bkkhack/hackmap.svg?branch=master
 [build link]: https://travis-ci.org/bkkhack/hackmap

--- a/src/components/Center.vue
+++ b/src/components/Center.vue
@@ -7,7 +7,7 @@
     <div class="droptarget"
       @dragover="dragover"
       @drop="drop">
-    <img src="../floorplan/learnhub.png" class="floorplan" />
+    <img v-bind:src="floorplan.url" class="floorplan" />
     <img class="marker" width="36"
       v-for="project in projects"
       v-if="project.x"
@@ -17,7 +17,7 @@
       @click="updateSelectedProject(project)"
       v-bind:class="{ selected: selectedProject === project }"
       v-bind:data-id="project.id"
-      v-bind:style="{ left: mapWidth * project.x - 20 + 'px', top: mapHeight * project.y - 20 + 'px' }"
+      v-bind:style="{ left: floorplan.width * project.x - 20 + 'px', top: floorplan.height * project.y - 20 + 'px' }"
       v-bind:src="project.avatar_thumbnail"
       v-bind:alt="project.username"
       v-bind:title="project.title"
@@ -29,7 +29,7 @@
 <script>
   export default {
     name: 'center',
-    props: ['mainThread', 'username', 'projects', 'selectedProject', 'mapWidth', 'mapHeight'],
+    props: ['mainThread', 'username', 'projects', 'selectedProject', 'floorplan'],
     methods: {
       dragover (event) {
         this.$emit('dragover', event)

--- a/src/components/Hackmap.vue
+++ b/src/components/Hackmap.vue
@@ -12,7 +12,7 @@
       @login="login" @logout="logout" @drop="centerDrop"
       :projects="projects" :selectedProject="selectedProject"
       :mainThread="mainThread" :username="username"
-      :mapWidth="mapWidth" :mapHeight="mapHeight"
+      :floorplan="floorplan"
       >
     </center>
     <right
@@ -45,9 +45,12 @@ export default {
         title: '',
         helpText: ''
       },
+      floorplan: {
+        url: '',
+        width: 0,
+        height: 0
+      },
       projects: [],
-      mapWidth: 0,
-      mapHeight: 0,
       form: {
         isOpen: false,
         title: '',
@@ -116,8 +119,8 @@ export default {
       var oldY = project.y
       // the map is a percentage width of the overall window, so we need
       // to save x and y as percentage values.
-      project.x = event.offsetX / this.mapWidth
-      project.y = event.offsetY / this.mapHeight
+      project.x = event.offsetX / this.floorplan.width
+      project.y = event.offsetY / this.floorplan.height
       githubIssue.updateProject(project)
         .catch(err => {
           console.log('update rejected', err)
@@ -126,9 +129,9 @@ export default {
         })
     },
     updateMapDimensions () {
-      var floorplan = this.$el.querySelector('.floorplan')
-      this.mapWidth = floorplan.clientWidth
-      this.mapHeight = floorplan.clientHeight
+      var floorplanElement = this.$el.querySelector('.floorplan')
+      this.floorplan.width = floorplanElement.clientWidth
+      this.floorplan.height = floorplanElement.clientHeight
     },
     login () {
       githubIssue.ensureAuthenticatedClient().then(data => console.log(data))
@@ -207,8 +210,9 @@ export default {
         }
       },
       onMainThreadLoaded: thread => {
-        this.mainThread.helpText = thread.body
+        this.mainThread.helpText = thread.helpText
         this.mainThread.title = thread.title
+        this.floorplan.url = thread.floorplanUrl
       },
       onUserAuthenticated: response => {
         this.username = response.data.login

--- a/src/github-issues.js
+++ b/src/github-issues.js
@@ -73,8 +73,10 @@ export default class GitHubIssueService {
       }
     }
 
-    this.config.onMainThreadLoaded(issue)
     this.issueNumber = issue.number
+
+    var thread = serialization.deserializeIssueToMainThread(issue)
+    this.config.onMainThreadLoaded(thread)
   }
 
   postNewProject (project) {

--- a/src/github-serialization.js
+++ b/src/github-serialization.js
@@ -3,6 +3,7 @@
  */
 
 const commentExtractionRegex = /<!-- ([.\d]+),([.\d]+) -->/
+const mainThreadAttributesRegex = /<!--\s*floorplan\s*:\s*([^,\s]+),?\s*-->/
 
 function parseCoordinatesFromComment (commentLines) {
   var lastLine = commentLines.slice(-1)[0]
@@ -43,5 +44,16 @@ export default {
       (project.descriptionText || '') + '\r\n' +
       `<!-- ${project.x},${project.y} -->`
     return body
+  },
+
+  deserializeIssueToMainThread: function (issue) {
+    let [, floorplanUrl] = mainThreadAttributesRegex.exec(issue.body)
+
+    return {
+      title: issue.title,
+      helpText: issue.body,
+      number: issue.number,
+      floorplanUrl: floorplanUrl
+    }
   }
 }

--- a/test/github-serialization.test.js
+++ b/test/github-serialization.test.js
@@ -16,5 +16,20 @@ describe('serialization', () => {
     expect(project.descriptionText).toEqual('time to take over the world!')
     expect(project.descriptionHtml).toEqual('<p>time to take over the world!</p>')
   })
+
+  it('should deserialize a github issue to a main thread object', () => {
+    let issue = {
+      number: 123,
+      title: 'Febtember 2018 Hacknight',
+      body: 'welcome to bkkhack!\r\n<!--\r\nfloorplan : http://www.example.com/foo.jpg\r\n -->'
+    }
+
+    let thread = serialization.deserializeIssueToMainThread(issue)
+
+    expect(thread.number).toEqual(123)
+    expect(thread.title).toEqual(issue.title)
+    expect(thread.helpText).toEqual(issue.body)
+    expect(thread.floorplanUrl).toEqual('http://www.example.com/foo.jpg')
+  })
 })
 


### PR DESCRIPTION
Adds support for configuring the background image in the issue description. Uses a format like this:

```html
<!--
floorplan: https://user-images.githubusercontent.com/97195/36626959-a06c2eda-196e-11e8-8138-12156da4d8b3.png
-->
```

Easiest way to use this feature is to upload the image directly to the GitHub issue, then use that generated URL.

I've already updated the [March 2018 main thread](https://github.com/bkkhack/hackmap/issues/47) to have this metadata.