### PR TITLE
fix bug preventing unauthenticated users from adding hack

### DIFF
--- a/src/github-issues.js
+++ b/src/github-issues.js
@@ -80,18 +80,18 @@ export default class GitHubIssueService {
   }
 
   postNewProject (project) {
-    return this.updateProjectAjaxCall(project, this.github.repo.post, 'issues/' + this.issueNumber + '/comments')
+    return this.updateProjectAjaxCall(project, 'post', 'issues/' + this.issueNumber + '/comments')
   }
 
   updateProject (project) {
-    return this.updateProjectAjaxCall(project, this.github.repo.patch, 'issues/comments/' + project.id)
+    return this.updateProjectAjaxCall(project, 'patch', 'issues/comments/' + project.id)
   }
 
-  updateProjectAjaxCall (project, ajaxCall, url) {
+  updateProjectAjaxCall (project, httpVerb, url) {
     return this.ensureAuthenticatedClient()
       .then(() => {
         let body = serialization.serializeProjectToComment(project)
-        return ajaxCall(url, { body: body }, {
+        return this.github.repo[httpVerb](url, { body: body }, {
           headers: serialization.commentFormat
         })
       })


### PR DESCRIPTION
when an unauthenticated user submits a hack, we should redirect them to
the github login page, and then after they've logged in, we should add
the hack they tried to submit.

however, because the ajax client was not authenticated at the beginning
of this process, the post-login ajax call fails with an HTTP 401.

to fix this, we no longer hold onto a reference to the ajax client, we just
get a new reference when making the post-login ajax call.