### PR TITLE
Allow admins to edit other people's hacks

### DIFF
--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -56,7 +56,8 @@ export default {
       user: {
         id: '',
         username: '',
-        hasProject: false
+        hasProject: false,
+        isAdmin: false
       }
     }
   },
@@ -196,9 +197,13 @@ export default {
       pollIntervalSeconds: 60,
       onProjectsUpdated: projects => {
         this.$set(this.$data, 'state', 'running')
-        this.user.hasProject = projects
-            .some(project => project.userId === this.user.id)
+        var projectForLoggedInUser = projects
+            .filter(project => project.userId === this.user.id)
 
+        if (projectForLoggedInUser.length) {
+          this.user.hasProject = true
+          this.user.isAdmin = projectForLoggedInUser[0].userIsAdmin
+        }
         // don't reset projects if the user is editing one of them
         if (!this.projects.some(project => project.editMode)) {
           this.projects = projects

--- a/src/components/hack-map.vue
+++ b/src/components/hack-map.vue
@@ -10,7 +10,7 @@
         v-for="project in projects"
         v-if="project.x > 0 && project.y > 0 && floorplan.width > 0 && floorplan.height > 0"
         v-bind:key="project.id"
-        v-bind:draggable="project.username === user.username"
+        v-bind:draggable="project.username === user.username || user.isAdmin"
         @dragstart="drag"
         @click.stop="updateSelectedProject(project.id)"
         v-bind:class="{ selected: selectedProjectId === project.id }"

--- a/src/components/side-bar.vue
+++ b/src/components/side-bar.vue
@@ -13,7 +13,7 @@
       v-bind:key="project.id"
       v-bind:data-id="project.id"
       v-bind:class="{ selected: selectedProjectId === project.id || project.editMode }"
-      v-bind:draggable="!(selectedProjectId === project.id && project.editMode) && project.username === user.username"
+      v-bind:draggable="!(selectedProjectId === project.id && project.editMode) && (project.username === user.username || user.isAdmin)"
       v-cloak
       class="project">
       <div class="project-title-bar">
@@ -28,7 +28,7 @@
         class="project-author-avatar" draggable="false" />
       <div v-if="!project.editMode" class="project-description" v-html="project.descriptionHtml"></div>
       <textarea v-else class="project-description-editor" v-model="project.descriptionText"></textarea>
-      <div class="action-button-bar" v-if="(selectedProjectId == project.id || project.editMode) && project.username === user.username">
+      <div class="action-button-bar" v-if="(selectedProjectId == project.id || project.editMode) && (project.username === user.username || user.isAdmin)">
         <a v-if="!project.editMode" class="edit action-button" @click="toggleEditMode(project.id)">Edit</a>
         <a v-if="!project.editMode" class="delete action-button" @click="deleteComment(project.id)">Delete</a>
         <a v-if="project.editMode" class="cancel action-button" @click="toggleEditMode(project.id)">Cancel</a>

--- a/src/github-serialization.js
+++ b/src/github-serialization.js
@@ -31,6 +31,8 @@ export default {
       descriptionHtml: descriptionHtml,
       username: comment.user.login,
       userId: comment.user.id,
+      // see https://developer.github.com/v4/reference/enum/commentauthorassociation/
+      userIsAdmin: comment.author_association === 'MEMBER' || comment.author_association === 'OWNER',
       avatar_thumbnail: comment.user.avatar_url + '&s=' + 40,
       avatar: comment.user.avatar_url + '&s=' + 80,
       x: coords.x,


### PR DESCRIPTION
This PR adds the ability for admins (where an admin is defined as a repository owner or a repository member) to move other people, as well as delete / edit their hacks. Closes https://github.com/bkkhack/hackmap/issues/9.
