### PR TITLE
use hash-based routing for historical event urls

### DIFF
--- a/src/github-issues.js
+++ b/src/github-issues.js
@@ -51,7 +51,10 @@ export default class GitHubIssueService {
   getIssues () {
     return this.github.repo
       .get('issues', {
-        params: { labels: this.config.label },
+        params: {
+          state: 'all', // supports viewing past threads that have since been closed.
+          labels: this.config.label
+        },
         headers: serialization.commentFormat
       })
       .then((response) => response.data)

--- a/src/main.js
+++ b/src/main.js
@@ -12,19 +12,18 @@ import {polyfill} from 'mobile-drag-drop'
 polyfill()
 
 const router = new Router({
-  mode: 'history',
   base: window.location.pathname,
   routes: [
     {
-      path: '',
-      name: 'lastest',
-      component: App
-    },
-    {
-      path: ':issueNumber',
+      path: '/events/:issueNumber',
       name: 'history',
       component: App,
       props: true
+    },
+    {
+      path: '*',
+      name: 'latest',
+      component: App
     }
   ]
 })


### PR DESCRIPTION
we can't use the currently configured html5 based routing, because then on refresh (or initial navigation), github would attempt to serve the HTML5 url, and respond with a 404. It appears that node.js servers solve this by routing all urls to the root page, so then the app would be served, and it could examine the url.

However, we are hosted on github pages, so we can't apply that configuration. So we'll use hash-based routing.